### PR TITLE
Allow Setting filename and inmemory config options

### DIFF
--- a/EazySDK/SettingsManager.cs
+++ b/EazySDK/SettingsManager.cs
@@ -6,9 +6,11 @@ namespace EazySDK
 {
     public class SettingsManager 
     {
-        public static IConfiguration CreateSettings()
+        public static IConfiguration CreateSettings(string filename)
         {
-            if (!File.Exists(Directory.GetCurrentDirectory() + "/appSettings.json"))
+            
+            if (String.IsNullOrEmpty(filename)) { filename = "appSettings.json"; }
+            if (!File.Exists(Directory.GetCurrentDirectory() + "/"+filename))
             {
                 SettingsWriter writer = new SettingsWriter();
             }
@@ -16,10 +18,47 @@ namespace EazySDK
 
             IConfiguration configuration = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("appSettings.json", optional: false, reloadOnChange: true)
+                .AddJsonFile(filename, optional: false, reloadOnChange: true)
                 .Build();
             return configuration;
         }
+        
+        public static IConfiguration CreateSettingsInMemory()
+        {
+            IConfiguration configuration = GetDefaultSettings();
+            return configuration;
+        }
+        
+        public static IConfiguration GetDefaultSettings()
+        {
+            var defaultOptions = new Dictionary<string, string>
+            {
+                { "currentEnvironment:Environment","ecm3" },
 
+                { "sandboxClientDetails:ApiKey","" },
+                { "sandboxClientDetails:ClientCode","" },
+
+                { "ecm3ClientDetails:ApiKey","" },
+                { "ecm3ClientDetails:ClientCode","" },
+
+                { "directDebitProcessingDays:InitialProcessingDays","10" },
+                { "directDebitProcessingDays:OngoingProcessingDays","5" },
+
+                { "contracts:AutoFixStartDate","false" },
+                { "contracts:AutoFixTerminationTypeAdHoc","false" },
+                { "contracts:AutoFixAtTheEndAdHoc","false" },
+                { "contracts:AutoFixPaymentDayInMonth","false" },
+                { "contracts:AutoFixPaymentMonthInYear","false" },
+
+                { "payments:AutoFixPaymentDate","false" },
+                { "payments:IsCreditAllowed","false" },
+
+                { "warnings:CustomerSearchWarning","false" },
+
+                { "other:BankHolidayUpdateDays","30" },                
+                { "other:ForceUpdateSchedulesOnRun","false" },
+            };
+            IConfiguration Settings = new ConfigurationBuilder().AddInMemoryCollection(defaultOptions).Build();                  
+            return Settings; 
     }
 }


### PR DESCRIPTION
This allows passing in filename or if null or empty then use appSettings.json.
For existing customers using appSettings.json when no filename is passed.
Anyone who want to use InMemory can call SettingsManager.CreateSettingsInMemory() which return same object that is returned by appSettings.json file.