### PR TITLE
Fix Post.Contract - use "99" rather than "last day of month"

### DIFF
--- a/EazySDK-UnitTests/Utilities/ContractChecks/PaymentDayInMonthCheck.cs
+++ b/EazySDK-UnitTests/Utilities/ContractChecks/PaymentDayInMonthCheck.cs
@@ -23,10 +23,17 @@ namespace EazySDK_UnitTests
         }
 
         [TestMethod]
-        public void TestLastDayOfMonthAcceptable()
+        public void Test99ForLastDayOfMonthAcceptable()
         {
-            bool PaymentDayInMonth = ContractCheck.CheckPaymentDayInMonthIsValid("last day of month");
+            bool PaymentDayInMonth = ContractCheck.CheckPaymentDayInMonthIsValid("99");
             Assert.IsTrue(PaymentDayInMonth);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(EazySDK.Exceptions.InvalidParameterException))]
+        public void TestLastDayOfMonthInvalid()
+        {
+            ContractCheck.CheckPaymentDayInMonthIsValid("last day of Month");
         }
 
         [TestMethod]

--- a/EazySDK/Post.cs
+++ b/EazySDK/Post.cs
@@ -201,7 +201,7 @@ namespace EazySDK
         /// <param name="PaymentAmount">Mandatory if the contract is not ad-hoc. The regular collection amount of the new contract</param>
         /// <param name="FinalAmount">Used if the final collection amount differs from the regular collection amount. Not to be used with ad-hoc contracts</param>
         /// <param name="PaymentMonthInYear">Mandatory for annual contracts. The collection month for annual payments (1-12)</param>
-        /// <param name="PaymentDayInMonth">Mandatory for annual and monthly contracts. The collection day of the month (1-28 || Last day of month)</param>
+        /// <param name="PaymentDayInMonth">Mandatory for annual and monthly contracts. The collection day of the month (1-28 || 99)</param>
         /// <param name="PaymentDayInWeek">Mandatory for weekly contracts. The collection day of the week for weekly schedules (Monday .. Friday)</param>
         /// <param name="TerminationDate">Mandatory if termination type is set to "End on exact date". The termination date of a contract</param>
         /// <param name="AdditionalReference">An additional, search-able reference for the newly created contract</param>
@@ -304,7 +304,7 @@ namespace EazySDK
                     }
                     else
                     {
-                        if (StartDateDateString.Substring(8, 2) != PaymentDayInMonth.PadLeft(2, '0'))
+                        if (PaymentDayInMonth != "99" && StartDateDateString.Substring(8, 2) != PaymentDayInMonth.PadLeft(2, '0'))
                         {
                             if (bool.Parse(Settings.GetSection("contracts")["AutoFixPaymentDayInMonth"]))
                             {
@@ -552,7 +552,7 @@ namespace EazySDK
         /// <param name="PaymentAmount">Mandatory if the contract is not ad-hoc. The regular collection amount for the restated contract/param>
         /// <param name="InitialAmount">Used if the first collection amount is different from the rest.Not to be used on ad-hoc contracts.</param>
         /// <param name="FinalAmount">Used if the final collection amount is different from the rest.Not to be used on ad-hoc contracts.</param>
-        /// <param name="PaymentDayInMonth">The collection day for monthly contracts.Accepts 1-28 or 'last day of month'</param>
+        /// <param name="PaymentDayInMonth">The collection day for monthly contracts. Accepts 1-28 or 99</param>
         /// <param name="PaymentMonthInYear">The collection month for annual contracts. Accepts 1-12</param>
         /// <param name="AdditionalReference">An additional reference for the newly created contract</param>
         /// 

--- a/EazySDK/Utilities/ContractPostChecks.cs
+++ b/EazySDK/Utilities/ContractPostChecks.cs
@@ -143,24 +143,18 @@ namespace EazySDK.Utilities
         {
             try
             {
-                if (int.Parse(PaymentDayInMonth) >= 1 && int.Parse(PaymentDayInMonth) <= 28)
+                if (PaymentDayInMonth == "99" || (int.Parse(PaymentDayInMonth) >= 1 && int.Parse(PaymentDayInMonth) <= 28))
                 {
                     return true;
                 }
                 else
                 {
-                    throw new Exceptions.InvalidParameterException(string.Format("{0} is not a valid PaymentDayInMonth. The PaymentDayInMonth must be between 1 and 28 or be set to 'last day of month'", PaymentDayInMonth));
+                    throw new FormatException(string.Format("{0} is not a valid PaymentDayInMonth. The PaymentDayInMonth must either be between 1 and 28, or be set to 99 to indicate the 'last day of month'", PaymentDayInMonth));
                 }
             }
             catch (FormatException)
             {
-                if (PaymentDayInMonth.ToLower() == "last day of month")
-                {
-                    return true;
-                } else
-                {
-                    throw new Exceptions.InvalidParameterException(string.Format("{0} is not a valid PaymentDayInMonth. The PaymentDayInMonth must be between 1 and 28 or be set to 'last day of month'", PaymentDayInMonth));
-                }
+                throw new Exceptions.InvalidParameterException(string.Format("{0} is not a valid PaymentDayInMonth. The PaymentDayInMonth must either be between 1 and 28, or be set to 99 to indicate the 'last day of month'", PaymentDayInMonth));
             }
         }
 


### PR DESCRIPTION
There is an bug in the SDK that looks for "last day of month" rather than "99" for monthly payment dates.

Issue reproduction before this PR:

If I put "99" as per the documentation, I am told: "PaymentDayInMonth must be set to 31 if the start date is 2022-07-31."
If I put a matching number, "31", I get told: "31 is not a valid PaymentDayInMonth. The PaymentDayInMonth must be between 1 and 28 or be set to 'last day of month'"
If I put "last day of month" as per the error message and GitHub source documentation, I get told: "PaymentDayInMonth must be set to 31 if the start date is 2022-07-31."

Based on testing the changes with the Sandbox API it shows that "99" is an acceptable value to indicate the last day of the month, and the literal string "last day of month" is not. I have changed the SDK logic, documentation and tests accordingly.

Note that the current version of `master` does not build because of a change to a couple of files needing an `IConfiguration` 
 / settings injected. I've left the fix for that out of this PR so that this remains focused on the logical issue.